### PR TITLE
Cross-compilation to Win32

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,24 @@ The `DESTDIR` and `PREFIX` can be configured as follows:
     cmake .. -DCMAKE_INSTALL_PREFIX:PATH=/usr
 
 
+Cross-compilation to Win32
+--------------------------
+
+MXE (http://mxe.cc) is needed. Follow its installation instructions,
+but you can build it with just the needed packages for sdl-jstest:
+
+    make gcc cmake sdl sdl2 ncurses pdcurses
+
+This still takes quite a while.
+
+After MXE installation finishes, for sdl-jstest compilation type:
+
+    mkdir build
+    cd build
+    i686-w64-mingw32.static-cmake ..
+    make
+
+
 Configuration
 -------------
 

--- a/sdl-jstest.c
+++ b/sdl-jstest.c
@@ -161,7 +161,8 @@ int main(int argc, char** argv)
         initscr();
 
         //cbreak();
-        //noecho();
+        noecho();
+        nodelay(stdscr, TRUE);
         //nonl();
         curs_set(0);
 
@@ -287,6 +288,11 @@ int main(int argc, char** argv)
             printw("Press Ctrl-c to exit\n");
 
             refresh();
+          }
+
+          if ( getch() == 3 ) // Ctrl-c
+          {
+            quit = 1;
           }
         } // while
 

--- a/sdl-jstest.c
+++ b/sdl-jstest.c
@@ -181,9 +181,9 @@ int main(int argc, char** argv)
         {
           SDL_Delay(10);
 
-          bool something_new = false;
+          bool something_new = FALSE;
           while (SDL_PollEvent(&event)) {
-            something_new = true;
+            something_new = TRUE;
             switch(event.type)
             {
               case SDL_JOYAXISMOTION:

--- a/sdl2-jstest.c
+++ b/sdl2-jstest.c
@@ -168,9 +168,9 @@ void test_joystick(int joy_idx)
     {
       SDL_Delay(10);
 
-      bool something_new = false;
+      bool something_new = FALSE;
       while (SDL_PollEvent(&event)) {
-        something_new = true;
+        something_new = TRUE;
         switch(event.type)
         {
           case SDL_JOYAXISMOTION:

--- a/sdl2-jstest.c
+++ b/sdl2-jstest.c
@@ -148,7 +148,8 @@ void test_joystick(int joy_idx)
     initscr();
 
     //cbreak();
-    //noecho();
+    noecho();
+    nodelay(stdscr, TRUE);
     //nonl();
     curs_set(0);
 
@@ -273,6 +274,11 @@ void test_joystick(int joy_idx)
         printw("Press Ctrl-c to exit\n");
 
         refresh();
+      }
+
+      if ( getch() == 3 ) // Ctrl-c
+      {
+        quit = 1;
       }
     } // while
 


### PR DESCRIPTION
Made some changes for MXE to work. This is a cross compiler environment that currently only targets Windows 32-bit.
Included changes:
- ANSI C "bool" usage. Actually, uses the definition from curses.h, but it's more compatible.
- Catching Ctrl-c when inside a curses screen and is not treated as SIGINT (happens in Windows).
- MXE usage instructions in readme.
Naturally, it still works as always in Linux.

Attached is the proof that it works :)
[sdl-jstest-win32.zip](https://github.com/Grumbel/sdl-jstest/files/1392176/sdl-jstest-win32.zip)
