### PR TITLE
Update test_rumble for SDL v2.0.18+

### DIFF
--- a/src/sdl2-jstest.c
+++ b/src/sdl2-jstest.c
@@ -555,6 +555,18 @@ static void test_rumble(int joy_idx)
   }
   else
   {
+#if SDL_VERSION_ATLEAST(2,0,18)
+    if (SDL_JoystickHasRumble(joy) == SDL_FALSE)
+    {
+      fprintf(stderr, "rumble not supported on joystick %d\n", joy_idx);
+    }
+    else
+    {
+      SDL_GameControllerUpdate();
+      SDL_JoystickRumble(joy, 0xFFFF, 0xFFFF, 3000);
+      SDL_Delay(3000);
+    }
+#else /* SDL_VERSION_ATLEAST(2,0,18) */
     SDL_Haptic* haptic = SDL_HapticOpenFromJoystick(joy);
     if (!haptic)
     {
@@ -581,6 +593,7 @@ static void test_rumble(int joy_idx)
       }
       SDL_HapticClose(haptic);
     }
+#endif /* SDL_VERSION_ATLEAST(2,0,18) */
     SDL_JoystickClose(joy);
   }
 }


### PR DESCRIPTION
Fix rumble not working with newer SDL2 releases.
See https://github.com/libsdl-org/SDL/issues/4970