### PR TITLE
build: set the cmake_minimum_required as a range

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...4.1)
 project(sdl-jstest)
 
 set(TINYCMMC_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/external/tinycmmc/modules/")


### PR DESCRIPTION
From the cmake documentation:
```
  This uses the <min>...<max> syntax to enable the NEW behaviors of
  policies introduced in CMake 4.1 and earlier while only requiring
  a minimum version of CMake 3.10.
```
Resource: https://cmake.org/cmake/help/latest/manual/cmake-policies.7.html#updating-projects
Gentoo-Issue: https://bugs.gentoo.org/964646